### PR TITLE
DN-3761 fix(answers): add JsonStringEnumConverter for converting

### DIFF
--- a/UvA.Workflow.Tests/InstanceUserStorageTests.cs
+++ b/UvA.Workflow.Tests/InstanceUserStorageTests.cs
@@ -60,7 +60,8 @@ public class InstanceUserStorageTests
                                        {
                                          "userName": "jdoe",
                                          "displayName": "Jane Doe",
-                                         "email": "j.doe@uva.nl"
+                                         "email": "j.doe@uva.nl",
+                                         "searchSource": "DataNose"
                                        }
                                        """).RootElement;
 

--- a/UvA.Workflow/WorkflowInstances/AnswerConversionService.cs
+++ b/UvA.Workflow/WorkflowInstances/AnswerConversionService.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http;
 using UvA.Workflow.DataNose;
 
@@ -15,7 +16,14 @@ public record AnswerInput(
 public class AnswerConversionService(IUserService userService)
 {
     public static readonly JsonSerializerOptions Options = new()
-        { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, PropertyNameCaseInsensitive = true };
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        Converters =
+        {
+            new JsonStringEnumConverter()
+        }
+    };
 
     /// <summary>
     /// Converts an answer input to a BsonValue based on the propertyDefinition's data type.


### PR DESCRIPTION
https://uvanose.atlassian.net/browse/DN-3761

The user picker was posting a valid user object, including:

`userName`, `displayName`, `email`, and `searchSource: "DataNose"`.

The backend tried to deserialize that payload into `UserSearchResult` using `AnswerConversionService.Options`, but those options did not include `JsonStringEnumConverter`. Because `searchSource` is an enum, the string value `"DataNose"` caused a `JsonException`.

That exception was swallowed by `ConvertUser`, which returned `BsonNull`. Since the current stored value was also null, the save path decided nothing had changed and skipped persistence. So after refresh, the examiner was gone because it had never actually been stored.

