### PR TITLE
DN-3692 fix: clear overrideRecipient value in workflow API configuration

### DIFF
--- a/Deployment/workflow-api-pr/values.yaml
+++ b/Deployment/workflow-api-pr/values.yaml
@@ -19,7 +19,6 @@ graph:
   tenantId: tenantId
   clientId: clientId
   userAccount: datanose@amsuni.onmicrosoft.com
-  overrideRecipient: testen-dn-fnwi@uva.nl
   
 surfConext:
   baseUrl: https://connect.test.surfconext.nl

--- a/Deployment/workflow-api/values.yaml
+++ b/Deployment/workflow-api/values.yaml
@@ -18,7 +18,6 @@ graph:
   tenantId: tenantId
   clientId: clientId
   userAccount: datanose@amsuni.onmicrosoft.com
-  overrideRecipient: testen-dn-fnwi@uva.nl
   
 surfConext:
   baseUrl: https://connect.test.surfconext.nl


### PR DESCRIPTION
these are now set in gitops repo, matching dn2s setup

[b248d72e9df31adaa7a8c3e273c00087fddfd77f](https://github.com/UvA-FNWI/DataNose-v2-gitops/commit/b248d72e9df31adaa7a8c3e273c00087fddfd77f)