### PR TITLE
fix: bug when creating instances through API

### DIFF
--- a/UvA.Workflow.Tests/InstanceUserStorageTests.cs
+++ b/UvA.Workflow.Tests/InstanceUserStorageTests.cs
@@ -411,4 +411,40 @@ public class InstanceUserStorageTests
         Assert.False(bson.Contains("AuthProvider"));
         Assert.False(bson.Contains("IsActive"));
     }
+
+    [Fact]
+    public async Task Create_WithUserProperty_DoesNotClobberSuppliedValue()
+    {
+        WorkflowInstance? created = null;
+        var repository = new Mock<IWorkflowInstanceRepository>();
+        repository.Setup(r => r.Create(It.IsAny<WorkflowInstance>(), It.IsAny<CancellationToken>()))
+            .Callback<WorkflowInstance, CancellationToken>((instance, _) => created = instance)
+            .Returns(Task.CompletedTask);
+        var service = new WorkflowInstanceService(ModelService, repository.Object, Mock.Of<IInstanceJournalService>());
+        var creator = new User
+        {
+            Id = ObjectId.GenerateNewId().ToString(),
+            UserName = "__ApiUser",
+            DisplayName = "Api",
+            Email = "api@invalid.uva.nl"
+        };
+
+        // An API caller (e.g. DN2) supplies the actual student in the initial properties.
+        var suppliedStudent = InstanceUser.FromUser(new User
+        {
+            Id = ObjectId.GenerateNewId().ToString(),
+            UserName = "student",
+            DisplayName = "Real Student",
+            Email = "s.tudent@uva.nl",
+            ProviderKey = EduIdDirectoryKeys.ProviderKey
+        }).ToBsonDocument();
+        var initialProperties = new Dictionary<string, BsonValue> { ["Student"] = suppliedStudent };
+
+        await service.Create("Project", creator, CancellationToken.None, userProperty: "Student",
+            initialProperties: initialProperties);
+
+        var bson = Assert.IsType<BsonDocument>(created!.Properties["Student"]);
+        Assert.Equal("student", bson["UserName"].AsString);
+        Assert.Equal("Real Student", bson["DisplayName"].AsString);
+    }
 }

--- a/UvA.Workflow/WorkflowInstances/WorkflowInstanceService.cs
+++ b/UvA.Workflow/WorkflowInstances/WorkflowInstanceService.cs
@@ -33,7 +33,11 @@ public class WorkflowInstanceService(
             Events = new Dictionary<string, InstanceEvent>()
         };
 
-        if (userProperty != null)
+        // userProperty (e.g. Student) records who an instance is "for". For self-service
+        // creation that's the creator, so default it to them. But a caller can also create
+        // on someone else's behalf e.g. the API provisioning a Project for a student, and
+        // supplies that user in the initial properties; in that case keep what was sent.
+        if (userProperty != null && !instance.Properties.ContainsKey(userProperty))
         {
             var user = InstanceUser.FromUser(createdBy).ToBsonDocument();
             var property = modelService.WorkflowDefinitions[workflowDefinition].Properties.Get(userProperty);


### PR DESCRIPTION
When creating an instance, `userProperty` (e.g. Student) was always set to the current user. That's fine for self-service, but when an API creates an instance on someone's behalf (DN2 provisioning a Project for a student) the supplied student got overwritten by the API user (`__ApiUser`).

Now we only default it to the creator when the property wasn't already supplied in the initial properties.
