### PR TITLE
Feature/dn 3886 pick substeps

### DIFF
--- a/UvA.Workflow.Tests/PresenceAwareInheritanceTests.cs
+++ b/UvA.Workflow.Tests/PresenceAwareInheritanceTests.cs
@@ -1,0 +1,173 @@
+namespace UvA.Workflow.Tests;
+
+public class PresenceAwareInheritanceTests
+{
+    private static Step Step(WorkflowDefinition def, string name) => def.AllSteps.Single(s => s.Name == name);
+
+    [Fact]
+    public void Step_ExplicitDefaultsAndEmptyList_WinOverParent()
+    {
+        var parser = new ModelParser(new DictionaryProvider(new()
+        {
+            ["Base/Entity.yaml"] = "name: Base\ntitlePlural: Bases\nsteps:\n  - S",
+            ["Base/Steps/S.yaml"] = "name: S\ntitle: BaseTitle\nhierarchyMode: Parallel\nchildren:\n  - A\n  - B",
+            ["Base/Steps/A.yaml"] = "name: A",
+            ["Base/Steps/B.yaml"] = "name: B",
+            ["Explicit/Entity.yaml"] = "name: Explicit\ntitlePlural: Es\ninheritsFrom: Base",
+            ["Explicit/Steps/S.yaml"] = "name: S\nhierarchyMode: Sequential\nchildren: []",
+            ["Omit/Entity.yaml"] = "name: Omit\ntitlePlural: Os\ninheritsFrom: Base",
+            ["Omit/Steps/S.yaml"] = "name: S\ntitle: NewTitle"
+        }));
+
+        var explicitStep = Step(parser.WorkflowDefinitions["Explicit"], "S");
+        Assert.Equal(StepHierarchyMode.Sequential, explicitStep.HierarchyMode);
+        Assert.Empty(explicitStep.ChildNames);
+        Assert.Equal("BaseTitle", explicitStep.Title!.En);
+
+        var omittedStep = Step(parser.WorkflowDefinitions["Omit"], "S");
+        Assert.Equal(StepHierarchyMode.Parallel, omittedStep.HierarchyMode);
+        Assert.Equal(["A", "B"], omittedStep.ChildNames);
+        Assert.Equal("NewTitle", omittedStep.Title!.En);
+    }
+
+    [Fact]
+    public void Events_MergeByName_ButExplicitEmptyClears()
+    {
+        var parser = new ModelParser(new DictionaryProvider(new()
+        {
+            ["Base/Entity.yaml"] = "name: Base\ntitlePlural: Bases\nevents:\n  - name: E1",
+            ["Merge/Entity.yaml"] = "name: Merge\ntitlePlural: Ms\ninheritsFrom: Base\nevents:\n  - name: E2",
+            ["Clear/Entity.yaml"] = "name: Clear\ntitlePlural: Cs\ninheritsFrom: Base\nevents: []"
+        }));
+
+        var merge = parser.WorkflowDefinitions["Merge"].Events.Select(e => e.Name).ToArray();
+        Assert.Contains("E1", merge);
+        Assert.Contains("E2", merge);
+
+        Assert.DoesNotContain("E1", parser.WorkflowDefinitions["Clear"].Events.Select(e => e.Name));
+    }
+
+    [Fact]
+    public void StepActions_RespectPresenceAndKeepAuthorizationInSync()
+    {
+        var parser = new ModelParser(new DictionaryProvider(new()
+        {
+            ["Common/Roles/Reviewer.yaml"] = "name: Reviewer",
+            ["Base/Entity.yaml"] = "name: Base\ntitlePlural: Bases\nsteps:\n  - Approval",
+            ["Base/Steps/Approval.yaml"] =
+                "name: Approval\ntitle: Approval\nactions:\n  - name: Approve\n    type: Execute\n    roles: [Reviewer]",
+            ["Omit/Entity.yaml"] = "name: Omit\ntitlePlural: Os\ninheritsFrom: Base",
+            ["Omit/Steps/Approval.yaml"] = "name: Approval\ntitle: Approved?",
+            ["Replace/Entity.yaml"] = "name: Replace\ntitlePlural: Rs\ninheritsFrom: Base",
+            ["Replace/Steps/Approval.yaml"] =
+                "name: Approval\nactions:\n  - name: Reject\n    type: Execute\n    roles: [Reviewer]",
+            ["Clear/Entity.yaml"] = "name: Clear\ntitlePlural: Cs\ninheritsFrom: Base",
+            ["Clear/Steps/Approval.yaml"] = "name: Approval\nactions: []"
+        }));
+
+        var reviewer = parser.Roles.Single(r => r.Name == "Reviewer");
+
+        Assert.Single(parser.WorkflowDefinitions["Omit"].AllActions, a => a.Name == "Approve");
+        Assert.Equal(1, reviewer.Actions.Count(a => a.WorkflowDefinition == "Omit" && a.Name == "Approve"));
+
+        Assert.DoesNotContain(parser.WorkflowDefinitions["Replace"].AllActions, a => a.Name == "Approve");
+        Assert.DoesNotContain(reviewer.Actions, a => a.WorkflowDefinition == "Replace" && a.Name == "Approve");
+        Assert.Single(parser.WorkflowDefinitions["Replace"].AllActions, a => a.Name == "Reject");
+
+        Assert.DoesNotContain(parser.WorkflowDefinitions["Clear"].AllActions, a => a.Name == "Approve");
+        Assert.DoesNotContain(reviewer.Actions, a => a.WorkflowDefinition == "Clear" && a.Name == "Approve");
+    }
+
+    [Fact]
+    public void GlobalActions_RespectPresenceAndRemainDiscoverable()
+    {
+        var parser = new ModelParser(new DictionaryProvider(new()
+        {
+            ["Common/Roles/Registered.yaml"] = "name: Registered",
+            ["Base/Entity.yaml"] =
+                "name: Base\ntitlePlural: Bases\nglobalActions:\n  - name: Make\n    type: CreateInstance\n    roles: [Registered]",
+            ["Omit/Entity.yaml"] = "name: Omit\ntitlePlural: Os\ninheritsFrom: Base",
+            ["Clear/Entity.yaml"] = "name: Clear\ntitlePlural: Cs\ninheritsFrom: Base\nglobalActions: []"
+        }));
+
+        var registered = parser.Roles.Single(r => r.Name == "Registered");
+
+        Assert.Single(parser.WorkflowDefinitions["Omit"].AllActions, a => a.Name == "Make");
+        Assert.Equal(1, registered.Actions.Count(a => a.WorkflowDefinition == "Omit" && a.Name == "Make"));
+
+        Assert.DoesNotContain(parser.WorkflowDefinitions["Clear"].AllActions, a => a.Name == "Make");
+        Assert.DoesNotContain(registered.Actions, a => a.WorkflowDefinition == "Clear" && a.Name == "Make");
+    }
+
+    [Fact]
+    public void AssessmentConfiguration_Inherited_ClearedByNull_OrReplaced()
+    {
+        var parser = new ModelParser(new DictionaryProvider(new()
+        {
+            ["Base/Entity.yaml"] =
+                "name: Base\ntitlePlural: Bases\nassessments:\n  parts:\n    - name: Whole\n      weight: 1",
+            ["Omit/Entity.yaml"] = "name: Omit\ntitlePlural: Os\ninheritsFrom: Base",
+            ["Nulled/Entity.yaml"] = "name: Nulled\ntitlePlural: Ns\ninheritsFrom: Base\nassessments:",
+            ["Replace/Entity.yaml"] =
+                "name: Replace\ntitlePlural: Rs\ninheritsFrom: Base\nassessments:\n  parts:\n    - name: Half\n      weight: 1"
+        }));
+
+        Assert.Equal("Whole",
+            parser.WorkflowDefinitions["Omit"].AssessmentConfiguration!.Parts.Single().Name);
+        Assert.Null(parser.WorkflowDefinitions["Nulled"].AssessmentConfiguration);
+        Assert.Equal("Half",
+            parser.WorkflowDefinitions["Replace"].AssessmentConfiguration!.Parts.Single().Name);
+    }
+
+    [Fact]
+    public void FormPages_MergeUnlessExplicitlyCleared()
+    {
+        var parser = new ModelParser(new DictionaryProvider(new()
+        {
+            ["Base/Entity.yaml"] = "name: Base\ntitlePlural: Bases\nproperties:\n  - name: Foo\n    type: String",
+            ["Base/Forms/Edit.yaml"] = "name: Edit\npages:\n  - name: P1\n    fields: [Foo]",
+            ["Merge/Entity.yaml"] = "name: Merge\ntitlePlural: Ms\ninheritsFrom: Base",
+            ["Merge/Forms/Edit.yaml"] = "name: Edit\npages:\n  - name: P2\n    fields: [Foo]",
+            ["Reject/Entity.yaml"] = "name: Reject\ntitlePlural: Rs\ninheritsFrom: Base",
+            ["Reject/Forms/Edit.yaml"] = "name: Edit\npages: []"
+        }));
+
+        var merged = parser.WorkflowDefinitions["Merge"].Forms.Single(f => f.Name == "Edit").Pages.Select(p => p.Name);
+        Assert.Equal(["P1", "P2"], merged);
+
+        // Empty forms get a generated page during preprocessing.
+        Assert.DoesNotContain("P1",
+            parser.WorkflowDefinitions["Reject"].Forms.Single(f => f.Name == "Edit").Pages.Select(p => p.Name));
+    }
+
+    [Fact]
+    public void Screens_ChildOverrideDoesNotCreateDuplicate()
+    {
+        var parser = new ModelParser(new DictionaryProvider(new()
+        {
+            ["Base/Entity.yaml"] = "name: Base\ntitlePlural: Bases",
+            ["Base/Screens/Main.yaml"] = "name: Main\ncolumns: []",
+            ["Child/Entity.yaml"] = "name: Child\ntitlePlural: Cs\ninheritsFrom: Base",
+            ["Child/Screens/Main.yaml"] = "name: Main\ncolumns: []"
+        }));
+
+        Assert.Single(parser.WorkflowDefinitions["Child"].Screens, s => s.Name == "Main");
+    }
+
+    [Fact]
+    public void ThreeLevelInheritance_PreservesExplicitIntermediateOverride()
+    {
+        var parser = new ModelParser(new DictionaryProvider(new()
+        {
+            ["Base/Entity.yaml"] = "name: Base\ntitlePlural: Bases\nsteps:\n  - S",
+            ["Base/Steps/S.yaml"] = "name: S\ntitle: BaseTitle\nhierarchyMode: Parallel",
+            ["Mid/Entity.yaml"] = "name: Mid\ntitlePlural: Ms\ninheritsFrom: Base",
+            ["Mid/Steps/S.yaml"] = "name: S\nhierarchyMode: Sequential",
+            ["Leaf/Entity.yaml"] = "name: Leaf\ntitlePlural: Ls\ninheritsFrom: Mid"
+        }));
+
+        var leafS = Step(parser.WorkflowDefinitions["Leaf"], "S");
+        Assert.Equal("BaseTitle", leafS.Title!.En);
+        Assert.Equal(StepHierarchyMode.Sequential, leafS.HierarchyMode);
+    }
+}

--- a/UvA.Workflow.Tests/PresenceAwareInheritanceTests.cs
+++ b/UvA.Workflow.Tests/PresenceAwareInheritanceTests.cs
@@ -48,7 +48,7 @@ public class PresenceAwareInheritanceTests
     }
 
     [Fact]
-    public void StepActions_RespectPresenceAndKeepAuthorizationInSync()
+    public void StepActions_MergeUnlessClearedAndKeepAuthorizationInSync()
     {
         var parser = new ModelParser(new DictionaryProvider(new()
         {
@@ -58,9 +58,9 @@ public class PresenceAwareInheritanceTests
                 "name: Approval\ntitle: Approval\nactions:\n  - name: Approve\n    type: Execute\n    roles: [Reviewer]",
             ["Omit/Entity.yaml"] = "name: Omit\ntitlePlural: Os\ninheritsFrom: Base",
             ["Omit/Steps/Approval.yaml"] = "name: Approval\ntitle: Approved?",
-            ["Replace/Entity.yaml"] = "name: Replace\ntitlePlural: Rs\ninheritsFrom: Base",
-            ["Replace/Steps/Approval.yaml"] =
-                "name: Approval\nactions:\n  - name: Reject\n    type: Execute\n    roles: [Reviewer]",
+            ["Merge/Entity.yaml"] = "name: Merge\ntitlePlural: Ms\ninheritsFrom: Base",
+            ["Merge/Steps/Approval.yaml"] =
+                "name: Approval\nactions:\n  - name: Approve\n    label: Child approval\n    type: Execute\n    roles: [Reviewer]\n  - name: Reject\n    type: Execute\n    roles: [Reviewer]",
             ["Clear/Entity.yaml"] = "name: Clear\ntitlePlural: Cs\ninheritsFrom: Base",
             ["Clear/Steps/Approval.yaml"] = "name: Approval\nactions: []"
         }));
@@ -70,16 +70,18 @@ public class PresenceAwareInheritanceTests
         Assert.Single(parser.WorkflowDefinitions["Omit"].AllActions, a => a.Name == "Approve");
         Assert.Equal(1, reviewer.Actions.Count(a => a.WorkflowDefinition == "Omit" && a.Name == "Approve"));
 
-        Assert.DoesNotContain(parser.WorkflowDefinitions["Replace"].AllActions, a => a.Name == "Approve");
-        Assert.DoesNotContain(reviewer.Actions, a => a.WorkflowDefinition == "Replace" && a.Name == "Approve");
-        Assert.Single(parser.WorkflowDefinitions["Replace"].AllActions, a => a.Name == "Reject");
+        Assert.Single(parser.WorkflowDefinitions["Merge"].AllActions, a => a.Name == "Approve");
+        Assert.Single(reviewer.Actions, a => a.WorkflowDefinition == "Merge" && a.Name == "Approve");
+        Assert.Equal("Child approval",
+            parser.WorkflowDefinitions["Merge"].AllActions.Single(a => a.Name == "Approve").Label!.En);
+        Assert.Single(parser.WorkflowDefinitions["Merge"].AllActions, a => a.Name == "Reject");
 
         Assert.DoesNotContain(parser.WorkflowDefinitions["Clear"].AllActions, a => a.Name == "Approve");
         Assert.DoesNotContain(reviewer.Actions, a => a.WorkflowDefinition == "Clear" && a.Name == "Approve");
     }
 
     [Fact]
-    public void GlobalActions_RespectPresenceAndRemainDiscoverable()
+    public void GlobalActions_MergeUnlessClearedAndRemainDiscoverable()
     {
         var parser = new ModelParser(new DictionaryProvider(new()
         {
@@ -87,6 +89,8 @@ public class PresenceAwareInheritanceTests
             ["Base/Entity.yaml"] =
                 "name: Base\ntitlePlural: Bases\nglobalActions:\n  - name: Make\n    type: CreateInstance\n    roles: [Registered]",
             ["Omit/Entity.yaml"] = "name: Omit\ntitlePlural: Os\ninheritsFrom: Base",
+            ["Merge/Entity.yaml"] =
+                "name: Merge\ntitlePlural: Ms\ninheritsFrom: Base\nglobalActions:\n  - name: Remove\n    type: Delete\n    roles: [Registered]",
             ["Clear/Entity.yaml"] = "name: Clear\ntitlePlural: Cs\ninheritsFrom: Base\nglobalActions: []"
         }));
 
@@ -94,6 +98,10 @@ public class PresenceAwareInheritanceTests
 
         Assert.Single(parser.WorkflowDefinitions["Omit"].AllActions, a => a.Name == "Make");
         Assert.Equal(1, registered.Actions.Count(a => a.WorkflowDefinition == "Omit" && a.Name == "Make"));
+
+        Assert.Single(parser.WorkflowDefinitions["Merge"].AllActions, a => a.Name == "Make");
+        Assert.Single(parser.WorkflowDefinitions["Merge"].AllActions, a => a.Name == "Remove");
+        Assert.Equal(2, registered.Actions.Count(a => a.WorkflowDefinition == "Merge"));
 
         Assert.DoesNotContain(parser.WorkflowDefinitions["Clear"].AllActions, a => a.Name == "Make");
         Assert.DoesNotContain(registered.Actions, a => a.WorkflowDefinition == "Clear" && a.Name == "Make");

--- a/UvA.Workflow.Tests/PresenceAwareInheritanceTests.cs
+++ b/UvA.Workflow.Tests/PresenceAwareInheritanceTests.cs
@@ -141,6 +141,30 @@ public class PresenceAwareInheritanceTests
     }
 
     [Fact]
+    public void RelatedUserGroups_ExplicitEmptyClearsInheritedGroups()
+    {
+        var parser = new ModelParser(new DictionaryProvider(new()
+        {
+            ["Base/Entity.yaml"] = """
+                                   name: Base
+                                   titlePlural: Bases
+                                   relatedUserGrouping:
+                                     groups:
+                                       - name: default
+                                   """,
+            ["Clear/Entity.yaml"] = """
+                                    name: Clear
+                                    titlePlural: Clears
+                                    inheritsFrom: Base
+                                    relatedUserGrouping:
+                                      groups: []
+                                    """
+        }));
+
+        Assert.Empty(parser.WorkflowDefinitions["Clear"].RelatedUserGrouping!.Groups);
+    }
+
+    [Fact]
     public void Resources_MergeUnlessExplicitlyCleared()
     {
         var parser = new ModelParser(new DictionaryProvider(new()

--- a/UvA.Workflow.Tests/PresenceAwareInheritanceTests.cs
+++ b/UvA.Workflow.Tests/PresenceAwareInheritanceTests.cs
@@ -141,6 +141,101 @@ public class PresenceAwareInheritanceTests
     }
 
     [Fact]
+    public void Resources_MergeUnlessExplicitlyCleared()
+    {
+        var parser = new ModelParser(new DictionaryProvider(new()
+        {
+            ["Base/Entity.yaml"] = """
+                                   name: Base
+                                   titlePlural: Bases
+                                   resources:
+                                     - name: Support
+                                       title: Support
+                                       type: Links
+                                       items:
+                                         - name: Handbook
+                                           type: Link
+                                           text: Handbook
+                                           url: https://example.com/handbook
+                                     - name: Guide
+                                       title: Guide
+                                       type: Text
+                                       content: Study guide
+                                   """,
+            ["Add/Entity.yaml"] = """
+                                  name: Add
+                                  titlePlural: Adds
+                                  inheritsFrom: Base
+                                  resources:
+                                    - name: Course
+                                      title: Course
+                                      type: Text
+                                      content: Course information
+                                  """,
+            ["Clear/Entity.yaml"] = """
+                                    name: Clear
+                                    titlePlural: Clears
+                                    inheritsFrom: Base
+                                    resources: []
+                                    """
+        }));
+
+        Assert.Equal(["Support", "Guide", "Course"],
+            parser.WorkflowDefinitions["Add"].Resources.Select(r => r.Name).ToArray());
+        Assert.Empty(parser.WorkflowDefinitions["Clear"].Resources);
+    }
+
+    [Fact]
+    public void ResourceItems_MergeUnlessExplicitlyCleared()
+    {
+        var parser = new ModelParser(new DictionaryProvider(new()
+        {
+            ["Base/Entity.yaml"] = """
+                                   name: Base
+                                   titlePlural: Bases
+                                   resources:
+                                     - name: Support
+                                       title: Support
+                                       type: Links
+                                       items:
+                                         - name: Handbook
+                                           type: Link
+                                           text: Handbook
+                                           url: https://example.com/handbook
+                                   """,
+            ["Add/Entity.yaml"] = """
+                                  name: Add
+                                  titlePlural: Adds
+                                  inheritsFrom: Base
+                                  resources:
+                                    - name: Support
+                                      title: Support
+                                      type: Links
+                                      items:
+                                        - name: Contact
+                                          type: Link
+                                          text: Contact
+                                          url: https://example.com/contact
+                                  """,
+            ["Clear/Entity.yaml"] = """
+                                    name: Clear
+                                    titlePlural: Clears
+                                    inheritsFrom: Base
+                                    resources:
+                                      - name: Support
+                                        title: Support
+                                        type: Text
+                                        content: Contact support
+                                        items: []
+                                    """
+        }));
+
+        Assert.Equal(["Contact", "Handbook"],
+            parser.WorkflowDefinitions["Add"].Resources.Single().Items!.Select(i => i.Name).ToArray());
+        Assert.Empty(parser.WorkflowDefinitions["Clear"].Resources.Single().Items!);
+    }
+
+    [Fact]
     public void Screens_ChildOverrideDoesNotCreateDuplicate()
     {
         var parser = new ModelParser(new DictionaryProvider(new()

--- a/UvA.Workflow.Tests/WorkflowInheritanceTests.cs
+++ b/UvA.Workflow.Tests/WorkflowInheritanceTests.cs
@@ -29,6 +29,93 @@ public class WorkflowInheritanceTests
     }
 
     [Fact]
+    public void ModelParser_MergesOverriddenStepWithParentStep()
+    {
+        var parser = new ModelParser(new DictionaryProvider(new()
+        {
+            ["Base/Entity.yaml"] = """
+                                   name: Base
+                                   titlePlural: Bases
+                                   steps:
+                                     - Review
+                                   """,
+            ["Base/Steps/Review.yaml"] = """
+                                         name: Review
+                                         title: Review
+                                         hierarchyMode: Parallel
+                                         children:
+                                           - SupervisorReview
+                                           - ExaminerReview
+                                         events:
+                                           - name: RequestRevision
+                                         """,
+            ["Base/Steps/SupervisorReview.yaml"] = "name: SupervisorReview",
+            ["Base/Steps/ExaminerReview.yaml"] = "name: ExaminerReview",
+            ["Child/Entity.yaml"] = """
+                                    name: Child
+                                    titlePlural: Children
+                                    inheritsFrom: Base
+                                    """,
+            ["Child/Steps/Review.yaml"] = """
+                                          name: Review
+                                          children:
+                                            - SupervisorReview
+                                          """
+        }));
+
+        var review = parser.WorkflowDefinitions["Child"].AllSteps.Single(step => step.Name == "Review");
+
+        Assert.Equal(["SupervisorReview"], review.Children.Select(child => child.Name).ToArray());
+        Assert.Equal(StepHierarchyMode.Parallel, review.HierarchyMode);
+        Assert.Equal("Review", review.Title!.En);
+        Assert.Contains(review.Events, ev => ev.Name == "RequestRevision");
+    }
+
+    [Fact]
+    public void ModelParser_RelinksInheritedParentsToOverriddenDescendants()
+    {
+        var parser = new ModelParser(new DictionaryProvider(new()
+        {
+            ["Base/Entity.yaml"] = "name: Base\ntitlePlural: Bases\nsteps:\n  - Thesis",
+            ["Base/Steps/Thesis.yaml"] = "name: Thesis\nchildren:\n  - Writing",
+            ["Base/Steps/Writing.yaml"] = "name: Writing\nchildren:\n  - Review",
+            ["Base/Steps/Review.yaml"] = "name: Review\nchildren:\n  - SupervisorReview\n  - ExaminerReview",
+            ["Base/Steps/SupervisorReview.yaml"] = "name: SupervisorReview",
+            ["Base/Steps/ExaminerReview.yaml"] = "name: ExaminerReview",
+            ["Child/Entity.yaml"] = "name: Child\ntitlePlural: Children\ninheritsFrom: Base",
+            ["Child/Steps/Review.yaml"] = "name: Review\nchildren:\n  - SupervisorReview"
+        }));
+
+        var child = parser.WorkflowDefinitions["Child"];
+        var review = child.Steps.Single(s => s.Name == "Thesis")
+            .Children.Single(s => s.Name == "Writing")
+            .Children.Single(s => s.Name == "Review");
+
+        Assert.Equal(["SupervisorReview"], review.Children.Select(c => c.Name).ToArray());
+        Assert.Equal(["SupervisorReview", "ExaminerReview"],
+            parser.WorkflowDefinitions["Base"].AllSteps.Single(s => s.Name == "Review")
+                .Children.Select(c => c.Name).ToArray());
+    }
+
+    [Fact]
+    public void ModelParser_OverridingStep_KeepsInheritedActionsInAllActions()
+    {
+        var parser = new ModelParser(new DictionaryProvider(new()
+        {
+            ["Common/Roles/Reviewer.yaml"] = "name: Reviewer",
+            ["Base/Entity.yaml"] = "name: Base\ntitlePlural: Bases\nsteps:\n  - Approval",
+            ["Base/Steps/Approval.yaml"] =
+                "name: Approval\ntitle: Approval\nactions:\n  - name: Approve\n    type: Execute\n    roles: [Reviewer]",
+            ["Child/Entity.yaml"] = "name: Child\ntitlePlural: Children\ninheritsFrom: Base",
+            ["Child/Steps/Approval.yaml"] = "name: Approval\ntitle: Approved?"
+        }));
+
+        var child = parser.WorkflowDefinitions["Child"];
+        Assert.Single(child.AllActions, a => a.Name == "Approve");
+        Assert.Equal("Approved?", child.AllSteps.Single(s => s.Name == "Approval").Title!.En);
+    }
+
+    [Fact]
     public void ModelParser_UsesRelatedUserPropertyDisplayNameAsDefaultTitle()
     {
         var parser = new ModelParser(new RelatedUserTitleContentProvider());

--- a/UvA.Workflow/WorkflowModel/Form.cs
+++ b/UvA.Workflow/WorkflowModel/Form.cs
@@ -67,8 +67,10 @@ public class Page : INamed
     }
 }
 
-public class Form : INamed
+public class Form : INamed, IDeclaredKeys
 {
+    [YamlIgnore] public HashSet<string> DeclaredKeys { get; set; } = new();
+
     /// <summary>
     /// Internal name of the form
     /// </summary>

--- a/UvA.Workflow/WorkflowModel/IDeclaredKeys.cs
+++ b/UvA.Workflow/WorkflowModel/IDeclaredKeys.cs
@@ -1,3 +1,7 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using YamlDotNet.Serialization.NamingConventions;
+
 namespace UvA.Workflow.WorkflowModel;
 
 /// <summary>Top-level keys present in the source YAML.</summary>
@@ -8,5 +12,13 @@ public interface IDeclaredKeys
 
 public static class DeclaredKeysExtensions
 {
-    public static bool Declared(this IDeclaredKeys source, string yamlKey) => source.DeclaredKeys.Contains(yamlKey);
+    public static bool Declared<T, TProperty>(this T source, Expression<Func<T, TProperty>> property)
+        where T : IDeclaredKeys
+    {
+        var member = (property.Body as MemberExpression)?.Member
+                     ?? throw new ArgumentException("A property selector is required", nameof(property));
+        var yamlKey = member.GetCustomAttribute<YamlMemberAttribute>()?.Alias
+                      ?? CamelCaseNamingConvention.Instance.Apply(member.Name);
+        return source.DeclaredKeys.Contains(yamlKey);
+    }
 }

--- a/UvA.Workflow/WorkflowModel/IDeclaredKeys.cs
+++ b/UvA.Workflow/WorkflowModel/IDeclaredKeys.cs
@@ -1,0 +1,12 @@
+namespace UvA.Workflow.WorkflowModel;
+
+/// <summary>Top-level keys present in the source YAML.</summary>
+public interface IDeclaredKeys
+{
+    [YamlIgnore] HashSet<string> DeclaredKeys { get; set; }
+}
+
+public static class DeclaredKeysExtensions
+{
+    public static bool Declared(this IDeclaredKeys source, string yamlKey) => source.DeclaredKeys.Contains(yamlKey);
+}

--- a/UvA.Workflow/WorkflowModel/Inheritance.cs
+++ b/UvA.Workflow/WorkflowModel/Inheritance.cs
@@ -51,8 +51,8 @@ public partial class ModelParser
         foreach (var screen in source.Screens.Where(s => !target.Screens.Contains(s.Name)))
             target.Screens.Add(screen);
 
-        if (!target.Declared("globalActions"))
-            target.GlobalActions = source.GlobalActions.Select(a => a.Clone()).ToList();
+        if (!Cleared(target, "globalActions", target.GlobalActions.Count))
+            target.GlobalActions = MergeActions(target.GlobalActions, source.GlobalActions);
 
         // Global and overridden-step actions are registered from the merged definition.
         var sourceGlobals = source.GlobalActions.ToHashSet();
@@ -147,6 +147,13 @@ public partial class ModelParser
         return result.ToArray();
     }
 
+    private static List<Action> MergeActions(List<Action> target, List<Action> source)
+    {
+        var targetNames = target.Select(a => a.Name).Where(n => n != null).ToHashSet();
+        return source.Where(a => a.Name == null || !targetNames.Contains(a.Name))
+            .Select(a => a.Clone()).Concat(target).ToList();
+    }
+
     private void ApplyInheritance(Form target, Form source)
     {
         if (Cleared(target, "pages", target.Pages.Count))
@@ -172,8 +179,8 @@ public partial class ModelParser
             foreach (var ev in source.Events.Where(e => !target.Events.Contains(e.Name)))
                 target.Events.Add(ev.Clone());
 
-        if (!target.Declared("actions"))
-            target.Actions = source.Actions.Select(a => a.Clone()).ToList();
+        if (!Cleared(target, "actions", target.Actions.Count))
+            target.Actions = MergeActions(target.Actions, source.Actions);
     }
 
     private void ApplyInheritance(SendMessage target, SendMessage source)

--- a/UvA.Workflow/WorkflowModel/Inheritance.cs
+++ b/UvA.Workflow/WorkflowModel/Inheritance.cs
@@ -90,7 +90,9 @@ public partial class ModelParser
                 .Concat(target.RelatedUsers)
                 .ToArray();
 
-        target.RelatedUserGrouping = MergeRelatedUserGrouping(target.RelatedUserGrouping, source.RelatedUserGrouping);
+        if (!Cleared(target, "relatedUserGrouping", target.RelatedUserGrouping?.Groups.Length ?? 0))
+            target.RelatedUserGrouping =
+                MergeRelatedUserGrouping(target.RelatedUserGrouping, source.RelatedUserGrouping);
         if (!Cleared(target, "resources", target.Resources.Length))
             target.Resources = MergeResources(target.Resources, source.Resources);
     }

--- a/UvA.Workflow/WorkflowModel/Inheritance.cs
+++ b/UvA.Workflow/WorkflowModel/Inheritance.cs
@@ -2,13 +2,17 @@ namespace UvA.Workflow.WorkflowModel;
 
 public partial class ModelParser
 {
+    // Explicit empty lists clear; omitted lists inherit or merge.
+    private static bool Cleared(IDeclaredKeys target, string key, int count) => target.Declared(key) && count == 0;
+
     private void ApplyInheritance(WorkflowDefinition target, WorkflowDefinition source)
     {
         target.Parent = source;
 
+        var declaredStepNames = target.AllSteps.Select(s => s.Name).ToHashSet();
+
         foreach (var sourceForm in source.Forms)
         {
-            // Target form matches on inheritsFrom property on form or on form name
             var targetForm = target.Forms.FirstOrDefault(tf => (tf.InheritsFrom ?? tf.Name) == sourceForm.Name);
             if (targetForm != null)
                 ApplyInheritance(targetForm, sourceForm);
@@ -16,17 +20,20 @@ public partial class ModelParser
                 target.Forms.Add(sourceForm.Clone());
         }
 
-        foreach (var property in source.Properties.Where(p =>
-                     !target.Properties.Contains(p.Name) && !target.AllSteps.SelectMany(s => s.Properties)
-                         .Select(s => s.Name).Contains(p.Name)))
-            target.Properties.Add(property);
+        if (!Cleared(target, "properties", target.Properties.Count))
+        {
+            var stepProperties = target.AllSteps.SelectMany(s => s.Properties).Select(s => s.Name).ToHashSet();
+            foreach (var property in source.Properties.Where(p =>
+                         !target.Properties.Contains(p.Name) && !stepProperties.Contains(p.Name)))
+                target.Properties.Add(property);
+        }
 
         foreach (var sourceStep in source.AllSteps)
         {
             if (target.AllSteps.TryGetValue(sourceStep.Name, out var targetStep))
                 ApplyInheritance(targetStep, sourceStep);
             else
-                target.AllSteps.Add(sourceStep);
+                target.AllSteps.Add(sourceStep.Clone());
         }
 
         foreach (var sourceMessage in source.Emails)
@@ -36,39 +43,53 @@ public partial class ModelParser
             else target.Emails.Add(sourceMessage);
         }
 
-        // Clone so a derived definition can generate its own suppression rules without
-        // mutating the shared parent/sibling event definitions (see resetParentStep expansion).
-        foreach (var ev in source.Events)
-            target.Events.Add(ev.Clone());
+        // Reset-parent processing mutates event definitions, so inherited events cannot be shared.
+        if (!Cleared(target, "events", target.Events.Count))
+            foreach (var ev in source.Events.Where(e => !target.Events.Contains(e.Name)))
+                target.Events.Add(ev.Clone());
 
-        foreach (var screen in source.Screens)
+        foreach (var screen in source.Screens.Where(s => !target.Screens.Contains(s.Name)))
             target.Screens.Add(screen);
 
+        if (!target.Declared("globalActions"))
+            target.GlobalActions = source.GlobalActions.Select(a => a.Clone()).ToList();
+
+        // Global and overridden-step actions are registered from the merged definition.
+        var sourceGlobals = source.GlobalActions.ToHashSet();
         foreach (var role in Roles)
-        foreach (var action in role.Actions.Where(a => a.WorkflowDefinition == source.Name).ToArray())
+        foreach (var action in role.Actions
+                     .Where(a => a.WorkflowDefinition == source.Name
+                                 && !sourceGlobals.Contains(a)
+                                 && !a.Steps.Any(declaredStepNames.Contains))
+                     .ToArray())
         {
             var newAction = action.Clone();
             newAction.WorkflowDefinition = target.Name;
             role.Actions.Add(newAction);
         }
 
-        if (target.StepNames.Count == 0)
-            target.StepNames = source.StepNames;
-        target.Title ??= source.Title;
-        target.TitlePlural ??= source.TitlePlural;
-        target.InstanceTitle ??= source.InstanceTitle;
-        target.IsEmbedded = source.IsEmbedded;
-        target.IsAlwaysVisible = source.IsAlwaysVisible;
+        if (!target.Declared("steps")) target.StepNames = source.StepNames;
+        if (!target.Declared("title")) target.Title = source.Title;
+        if (!target.Declared("titlePlural")) target.TitlePlural = source.TitlePlural;
+        if (!target.Declared("instanceTitle")) target.InstanceTitle = source.InstanceTitle;
+        if (!target.Declared("isEmbedded")) target.IsEmbedded = source.IsEmbedded;
+        if (!target.Declared("isAlwaysVisible")) target.IsAlwaysVisible = source.IsAlwaysVisible;
+        if (!target.Declared("assessments")) target.AssessmentConfiguration = source.AssessmentConfiguration;
 
-        var targetProperties = target.Fields.Select(f => f.Property).ToHashSet();
-        target.Fields = source.Fields.Where(f => !targetProperties.Contains(f.Property)).Concat(target.Fields)
-            .ToArray();
+        if (!Cleared(target, "fields", target.Fields.Length))
+        {
+            var targetProperties = target.Fields.Select(f => f.Property).ToHashSet();
+            target.Fields = source.Fields.Where(f => !targetProperties.Contains(f.Property))
+                .Concat(target.Fields).ToArray();
+        }
 
-        target.RelatedUsers = source.RelatedUsers
-            .Where(sourceRelatedUser => target.RelatedUsers.All(targetRelatedUser =>
-                targetRelatedUser.Property != sourceRelatedUser.Property))
-            .Concat(target.RelatedUsers)
-            .ToArray();
+        if (!Cleared(target, "relatedUsers", target.RelatedUsers.Length))
+            target.RelatedUsers = source.RelatedUsers
+                .Where(sourceRelatedUser => target.RelatedUsers.All(targetRelatedUser =>
+                    targetRelatedUser.Property != sourceRelatedUser.Property))
+                .Concat(target.RelatedUsers)
+                .ToArray();
+
         target.RelatedUserGrouping = MergeRelatedUserGrouping(target.RelatedUserGrouping, source.RelatedUserGrouping);
     }
 
@@ -92,12 +113,31 @@ public partial class ModelParser
 
     private void ApplyInheritance(Form target, Form source)
     {
+        if (Cleared(target, "pages", target.Pages.Count))
+            return;
         foreach (var sourcePage in source.Pages.Where(p => !target.Pages.Contains(p.Name)))
-            target.Pages.Insert(0, sourcePage.Clone()); // prepend parent pages before child-specific ones
+            target.Pages.Insert(0, sourcePage.Clone());
     }
 
     private void ApplyInheritance(Step target, Step source)
     {
+        if (!target.Declared("title")) target.Title = source.Title;
+        if (!target.Declared("progress")) target.Progress = source.Progress;
+        if (!target.Declared("icon")) target.Icon = source.Icon;
+        if (!target.Declared("headerStatus")) target.HeaderStatus = source.HeaderStatus;
+        if (!target.Declared("condition")) target.Condition = source.Condition;
+        if (!target.Declared("ends")) target.Ends = source.Ends;
+        if (!target.Declared("hierarchyMode")) target.HierarchyMode = source.HierarchyMode;
+        if (!target.Declared("resultsType")) target.ResultsType = source.ResultsType;
+        if (!target.Declared("children")) target.ChildNames = source.ChildNames;
+
+        // Reset-parent processing mutates event definitions, so inherited events cannot be shared.
+        if (!Cleared(target, "events", target.Events.Count))
+            foreach (var ev in source.Events.Where(e => !target.Events.Contains(e.Name)))
+                target.Events.Add(ev.Clone());
+
+        if (!target.Declared("actions"))
+            target.Actions = source.Actions.Select(a => a.Clone()).ToList();
     }
 
     private void ApplyInheritance(SendMessage target, SendMessage source)

--- a/UvA.Workflow/WorkflowModel/Inheritance.cs
+++ b/UvA.Workflow/WorkflowModel/Inheritance.cs
@@ -91,7 +91,8 @@ public partial class ModelParser
                 .ToArray();
 
         target.RelatedUserGrouping = MergeRelatedUserGrouping(target.RelatedUserGrouping, source.RelatedUserGrouping);
-        target.Resources = MergeResources(target.Resources, source.Resources);
+        if (!Cleared(target, "resources", target.Resources.Length))
+            target.Resources = MergeResources(target.Resources, source.Resources);
     }
 
     private static RelatedUserGrouping? MergeRelatedUserGrouping(RelatedUserGrouping? target,
@@ -116,16 +117,18 @@ public partial class ModelParser
     {
         var result = target.ToList();
 
-        foreach (var sourceResource in source)
+        foreach (var sourceResource in source.Reverse())
         {
             var targetResource = result.FirstOrDefault(r => r.Name == sourceResource.Name);
             if (targetResource == null)
             {
-                result.Insert(0, sourceResource); // prepend inherited resources
+                result.Insert(0, sourceResource);
                 continue;
             }
 
             if (sourceResource.Items == null) continue;
+
+            if (targetResource.Items is { Length: 0 }) continue;
 
             if (targetResource.Items == null)
             {
@@ -133,7 +136,6 @@ public partial class ModelParser
                 continue;
             }
 
-            // Merge items: child's items take priority, append source items not already present
             var targetItemNames = targetResource.Items.Select(i => i.Name).ToHashSet();
             targetResource.Items = targetResource.Items
                 .Concat(sourceResource.Items.Where(i => !targetItemNames.Contains(i.Name)))

--- a/UvA.Workflow/WorkflowModel/Inheritance.cs
+++ b/UvA.Workflow/WorkflowModel/Inheritance.cs
@@ -1,9 +1,15 @@
+using System.Collections;
+using System.Linq.Expressions;
+
 namespace UvA.Workflow.WorkflowModel;
 
 public partial class ModelParser
 {
     // Explicit empty lists clear; omitted lists inherit or merge.
-    private static bool Cleared(IDeclaredKeys target, string key, int count) => target.Declared(key) && count == 0;
+    private static bool Cleared<T, TCollection>(T target, Expression<Func<T, TCollection>> property)
+        where T : IDeclaredKeys
+        where TCollection : ICollection =>
+        target.Declared(property) && property.Compile()(target).Count == 0;
 
     private void ApplyInheritance(WorkflowDefinition target, WorkflowDefinition source)
     {
@@ -20,7 +26,7 @@ public partial class ModelParser
                 target.Forms.Add(sourceForm.Clone());
         }
 
-        if (!Cleared(target, "properties", target.Properties.Count))
+        if (!Cleared(target, d => d.Properties))
         {
             var stepProperties = target.AllSteps.SelectMany(s => s.Properties).Select(s => s.Name).ToHashSet();
             foreach (var property in source.Properties.Where(p =>
@@ -44,14 +50,14 @@ public partial class ModelParser
         }
 
         // Reset-parent processing mutates event definitions, so inherited events cannot be shared.
-        if (!Cleared(target, "events", target.Events.Count))
+        if (!Cleared(target, d => d.Events))
             foreach (var ev in source.Events.Where(e => !target.Events.Contains(e.Name)))
                 target.Events.Add(ev.Clone());
 
         foreach (var screen in source.Screens.Where(s => !target.Screens.Contains(s.Name)))
             target.Screens.Add(screen);
 
-        if (!Cleared(target, "globalActions", target.GlobalActions.Count))
+        if (!Cleared(target, d => d.GlobalActions))
             target.GlobalActions = MergeActions(target.GlobalActions, source.GlobalActions);
 
         // Global and overridden-step actions are registered from the merged definition.
@@ -68,32 +74,35 @@ public partial class ModelParser
             role.Actions.Add(newAction);
         }
 
-        if (!target.Declared("steps")) target.StepNames = source.StepNames;
-        if (!target.Declared("title")) target.Title = source.Title;
-        if (!target.Declared("titlePlural")) target.TitlePlural = source.TitlePlural;
-        if (!target.Declared("instanceTitle")) target.InstanceTitle = source.InstanceTitle;
-        if (!target.Declared("isEmbedded")) target.IsEmbedded = source.IsEmbedded;
-        if (!target.Declared("isAlwaysVisible")) target.IsAlwaysVisible = source.IsAlwaysVisible;
-        if (!target.Declared("assessments")) target.AssessmentConfiguration = source.AssessmentConfiguration;
+        if (!target.Declared(d => d.StepNames)) target.StepNames = source.StepNames;
+        if (!target.Declared(d => d.Title)) target.Title = source.Title;
+        if (!target.Declared(d => d.TitlePlural)) target.TitlePlural = source.TitlePlural;
+        if (!target.Declared(d => d.InstanceTitle)) target.InstanceTitle = source.InstanceTitle;
+        if (!target.Declared(d => d.IsEmbedded)) target.IsEmbedded = source.IsEmbedded;
+        if (!target.Declared(d => d.IsAlwaysVisible)) target.IsAlwaysVisible = source.IsAlwaysVisible;
+        if (!target.Declared(d => d.AssessmentConfiguration))
+            target.AssessmentConfiguration = source.AssessmentConfiguration;
 
-        if (!Cleared(target, "fields", target.Fields.Length))
+        if (!Cleared(target, d => d.Fields))
         {
             var targetProperties = target.Fields.Select(f => f.Property).ToHashSet();
             target.Fields = source.Fields.Where(f => !targetProperties.Contains(f.Property))
                 .Concat(target.Fields).ToArray();
         }
 
-        if (!Cleared(target, "relatedUsers", target.RelatedUsers.Length))
+        if (!Cleared(target, d => d.RelatedUsers))
             target.RelatedUsers = source.RelatedUsers
                 .Where(sourceRelatedUser => target.RelatedUsers.All(targetRelatedUser =>
                     targetRelatedUser.Property != sourceRelatedUser.Property))
                 .Concat(target.RelatedUsers)
                 .ToArray();
 
-        if (!Cleared(target, "relatedUserGrouping", target.RelatedUserGrouping?.Groups.Length ?? 0))
+        var groupingCleared = target.Declared(d => d.RelatedUserGrouping)
+                              && (target.RelatedUserGrouping == null || target.RelatedUserGrouping.Groups.Length == 0);
+        if (!groupingCleared)
             target.RelatedUserGrouping =
                 MergeRelatedUserGrouping(target.RelatedUserGrouping, source.RelatedUserGrouping);
-        if (!Cleared(target, "resources", target.Resources.Length))
+        if (!Cleared(target, d => d.Resources))
             target.Resources = MergeResources(target.Resources, source.Resources);
     }
 
@@ -156,7 +165,7 @@ public partial class ModelParser
 
     private void ApplyInheritance(Form target, Form source)
     {
-        if (Cleared(target, "pages", target.Pages.Count))
+        if (Cleared(target, f => f.Pages))
             return;
         foreach (var sourcePage in source.Pages.Where(p => !target.Pages.Contains(p.Name)))
             target.Pages.Insert(0, sourcePage.Clone());
@@ -164,22 +173,22 @@ public partial class ModelParser
 
     private void ApplyInheritance(Step target, Step source)
     {
-        if (!target.Declared("title")) target.Title = source.Title;
-        if (!target.Declared("progress")) target.Progress = source.Progress;
-        if (!target.Declared("icon")) target.Icon = source.Icon;
-        if (!target.Declared("headerStatus")) target.HeaderStatus = source.HeaderStatus;
-        if (!target.Declared("condition")) target.Condition = source.Condition;
-        if (!target.Declared("ends")) target.Ends = source.Ends;
-        if (!target.Declared("hierarchyMode")) target.HierarchyMode = source.HierarchyMode;
-        if (!target.Declared("resultsType")) target.ResultsType = source.ResultsType;
-        if (!target.Declared("children")) target.ChildNames = source.ChildNames;
+        if (!target.Declared(s => s.Title)) target.Title = source.Title;
+        if (!target.Declared(s => s.Progress)) target.Progress = source.Progress;
+        if (!target.Declared(s => s.Icon)) target.Icon = source.Icon;
+        if (!target.Declared(s => s.HeaderStatus)) target.HeaderStatus = source.HeaderStatus;
+        if (!target.Declared(s => s.Condition)) target.Condition = source.Condition;
+        if (!target.Declared(s => s.Ends)) target.Ends = source.Ends;
+        if (!target.Declared(s => s.HierarchyMode)) target.HierarchyMode = source.HierarchyMode;
+        if (!target.Declared(s => s.ResultsType)) target.ResultsType = source.ResultsType;
+        if (!target.Declared(s => s.ChildNames)) target.ChildNames = source.ChildNames;
 
         // Reset-parent processing mutates event definitions, so inherited events cannot be shared.
-        if (!Cleared(target, "events", target.Events.Count))
+        if (!Cleared(target, s => s.Events))
             foreach (var ev in source.Events.Where(e => !target.Events.Contains(e.Name)))
                 target.Events.Add(ev.Clone());
 
-        if (!Cleared(target, "actions", target.Actions.Count))
+        if (!Cleared(target, s => s.Actions))
             target.Actions = MergeActions(target.Actions, source.Actions);
     }
 

--- a/UvA.Workflow/WorkflowModel/ModelParser.cs
+++ b/UvA.Workflow/WorkflowModel/ModelParser.cs
@@ -1,6 +1,7 @@
 using Serilog;
 using UvA.Workflow.WorkflowModel.Conditions;
 using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization.NamingConventions;
 using Path = System.IO.Path;
 
@@ -68,6 +69,7 @@ public partial class ModelParser
                          .Where(f => Path.GetFileName(f) != "Entity.yaml"))
             {
                 var content = Parse<WorkflowDefinition>(file);
+                definition.DeclaredKeys.UnionWith(content.DeclaredKeys);
                 foreach (var prop in content.Properties)
                 {
                     if (definition.Properties.Contains(prop.Name))
@@ -86,6 +88,7 @@ public partial class ModelParser
             definition.Forms = Read<Form>(definition.SourceFolder);
             definition.Screens = Read<Screen>(definition.SourceFolder);
             definition.AllSteps = Read<Step>(definition.SourceFolder);
+            var declaredStepNames = definition.AllSteps.Select(s => s.Name).ToHashSet();
             definition.Emails = Read<TemplateMessage>(definition.SourceFolder);
 
             foreach (var entry in Read<Condition>(definition.SourceFolder))
@@ -111,10 +114,12 @@ public partial class ModelParser
                     Roles.Get(role).Actions.Add(action);
             }
 
-            foreach (var step in
-                     definition.AllSteps.Except((IEnumerable<Step>?)definition.Parent?.AllSteps ?? []))
-            {
+            // Inherited parents must resolve child references against this definition's steps.
+            foreach (var step in definition.AllSteps)
                 step.Children = step.ChildNames.Select(s => definition.AllSteps.Get(s)).ToArray();
+
+            foreach (var step in definition.AllSteps.Where(s => declaredStepNames.Contains(s.Name)))
+            {
                 foreach (var action in step.Actions)
                 {
                     action.WorkflowDefinition = definition.Name;
@@ -522,16 +527,36 @@ public partial class ModelParser
 
     private T Parse<T>(string file)
     {
+        var content = _contentProvider.GetFile(file);
         try
         {
             Log.Debug("Parsing {File} for {Type}", file, typeof(T).Name);
-            var obj = _deserializer.Deserialize<T>(_contentProvider.GetFile(file));
+            var obj = _deserializer.Deserialize<T>(content);
+            if (obj is IDeclaredKeys tracked)
+                tracked.DeclaredKeys = ReadTopLevelKeys(content);
             return obj;
         }
         catch (YamlException ex)
         {
             throw new Exception($"Failed to parse {file}:{ex.Start.Line}:{ex.Start.Column}. {ex.Message}");
         }
+    }
+
+    // Deserialization loses the distinction between omitted keys and explicit default values.
+    private static HashSet<string> ReadTopLevelKeys(string content)
+    {
+        var keys = new HashSet<string>();
+        var parser = new Parser(new StringReader(content));
+        parser.Consume<StreamStart>();
+        if (!parser.TryConsume<DocumentStart>(out _) || !parser.TryConsume<MappingStart>(out _))
+            return keys;
+        while (parser.TryConsume<Scalar>(out var key))
+        {
+            keys.Add(key.Value);
+            parser.SkipThisAndNestedEvents();
+        }
+
+        return keys;
     }
 
     private List<T> Read<T>(string? root = null)

--- a/UvA.Workflow/WorkflowModel/Step.cs
+++ b/UvA.Workflow/WorkflowModel/Step.cs
@@ -44,8 +44,10 @@ public enum StepResultsType
     AssessmentFinalOverview
 }
 
-public class Step : INamed
+public class Step : INamed, IDeclaredKeys
 {
+    [YamlIgnore] public HashSet<string> DeclaredKeys { get; set; } = new();
+
     /// <summary>
     /// Internal name of the step
     /// </summary>
@@ -86,6 +88,9 @@ public class Step : INamed
 
     [YamlIgnore] public Step[] Children { get; set; } = [];
     [YamlIgnore] public Step? ParentStep { get; set; }
+
+    // Derived definitions relink Children, so inherited steps cannot be shared.
+    public Step Clone() => (Step)MemberwiseClone();
 
     public List<StepHeaderStatusConfiguration>? HeaderStatus { get; set; }
 

--- a/UvA.Workflow/WorkflowModel/WorkflowDefinition.cs
+++ b/UvA.Workflow/WorkflowModel/WorkflowDefinition.cs
@@ -6,8 +6,10 @@ namespace UvA.Workflow.WorkflowModel;
 /// <summary>
 /// Represents a type of object ("entity") in the workflow system
 /// </summary>
-public class WorkflowDefinition : INamed
+public class WorkflowDefinition : INamed, IDeclaredKeys
 {
+    [YamlIgnore] public HashSet<string> DeclaredKeys { get; set; } = new();
+
     /// <summary>
     /// Short internal name of the entity type
     /// </summary>


### PR DESCRIPTION
DN-3886

## Summary

This adds support for overriding individual substeps in an inherited
workflow without having to redefine the complete parent step hierarchy.

For example, a child workflow can override Review or one of its descendants
while the remaining step configuration is inherited from the parent.

## What changed

- Child steps are merged with matching parent steps.
- Inherited parent steps are relinked to overridden child descendants.
- Explicit YAML values now win, including default values such as Sequential,
  Normal, false, [], and null.

- Multi-level inheritance is processed parent-first and inheritance cycles
  are rejected.

- Collection inheritance was made consistent for fields, properties, events,
  related users, groups, form pages, resources, and resource items.

## Inheritance rules

The general contract is:

- Omitted property: inherit from the parent.
- Explicit property: use the child value, including default values or null.
- Named collection: merge parent and child entries by name/key.
- Matching collection entry: the child entry wins.
- Empty collection: clear the complete inherited collection.
- Individual inherited collection entries cannot currently be removed.


Resources merge by resource name, and their items merge by item name.
Declaring `items: []` clears the inherited items for that resource. A child
resource still defines its own metadata such as title and type.