### PR TITLE
DN-3931 chore: camel case endpoints

### DIFF
--- a/Deployment/workflow-api-pr/values.yaml
+++ b/Deployment/workflow-api-pr/values.yaml
@@ -62,11 +62,10 @@ apiPaths:
   - /Users
   - /Organizations
   - /WorkflowInstances
-  - /Submissions
-  - /Artifacts
   - /Assessments
   - /Personal
   - /Jobs
+  - /Steps
   - /oidc
   - /signin-oidc
 

--- a/UvA.Workflow.Api/Jobs/JobsController.cs
+++ b/UvA.Workflow.Api/Jobs/JobsController.cs
@@ -32,7 +32,7 @@ public class JobsController(
         return Ok(await ToDto(job, ct));
     }
 
-    [HttpPost("{instanceId}/{jobId}/run")]
+    [HttpPost("{instanceId}/{jobId}/Run")]
     public async Task<ActionResult<JobDto>> Run(string instanceId, string jobId, CancellationToken ct)
     {
         await rightsService.EnsureAuthorizedForAction(RoleAction.ViewAdminTools);

--- a/UvA.Workflow.Api/Organizations/OrganizationsController.cs
+++ b/UvA.Workflow.Api/Organizations/OrganizationsController.cs
@@ -33,7 +33,7 @@ public class OrganizationsController(
         return Ok(organizations.Select(OrganizationDto.Create));
     }
 
-    [HttpGet("find")]
+    [HttpGet("Find")]
     public async Task<ActionResult<IEnumerable<OrganizationDto>>> Find(string query, int? limit,
         CancellationToken ct)
     {

--- a/UvA.Workflow.Api/Steps/StepsController.cs
+++ b/UvA.Workflow.Api/Steps/StepsController.cs
@@ -14,7 +14,7 @@ public class StepsController(
     /// <summary>
     /// Gets all versions of a step with their submission history
     /// </summary>
-    [HttpGet("/api/instances/{instanceId}/steps/{stepName}/versions")]
+    [HttpGet("{instanceId}/{stepName}/Versions")]
     public async Task<ActionResult<List<StepVersion>>> GetStepVersions(
         string instanceId,
         string stepName,

--- a/UvA.Workflow.Api/Submissions/AnswersController.cs
+++ b/UvA.Workflow.Api/Submissions/AnswersController.cs
@@ -48,7 +48,7 @@ public class AnswersController(
         }
     }
 
-    [HttpPost("{instanceId}/{submissionId}/{questionName}/artifacts")]
+    [HttpPost("{instanceId}/{submissionId}/{questionName}/Artifacts")]
     [Consumes("multipart/form-data")]
     [Produces("application/json")]
     public async Task<ActionResult<SaveAnswerResponse>> SaveAnswerFile(string instanceId, string submissionId,
@@ -62,7 +62,7 @@ public class AnswersController(
         return Ok(new SaveAnswerFileResponse(true));
     }
 
-    [HttpDelete("{instanceId}/{submissionId}/{questionName}/artifacts/{artifactId}")]
+    [HttpDelete("{instanceId}/{submissionId}/{questionName}/Artifacts/{artifactId}")]
     public async Task<IActionResult> DeleteAnswerFile(string instanceId, string submissionId, string questionName,
         string artifactId, CancellationToken ct)
     {
@@ -74,7 +74,7 @@ public class AnswersController(
     }
 
     [AllowAnonymous]
-    [HttpGet("{instanceId}/{submissionId}/{questionName}/artifacts/{artifactId}")]
+    [HttpGet("{instanceId}/{submissionId}/{questionName}/Artifacts/{artifactId}")]
     public async Task<IActionResult> GetAnswerFile(string instanceId, string submissionId, string questionName,
         string artifactId, [FromQuery] string token, CancellationToken ct)
     {

--- a/UvA.Workflow.Api/Submissions/SubmissionsController.cs
+++ b/UvA.Workflow.Api/Submissions/SubmissionsController.cs
@@ -70,7 +70,7 @@ public class SubmissionsController(
             EffectResult: result.EffectResult));
     }
 
-    [HttpPost("{instanceId}/{submissionId}/dummyData")]
+    [HttpPost("{instanceId}/{submissionId}/DummyData")]
     public async Task<ActionResult<SubmissionDto>> GenerateDummyData(string instanceId, string submissionId,
         CancellationToken ct)
     {

--- a/UvA.Workflow.Api/Users/UsersController.cs
+++ b/UvA.Workflow.Api/Users/UsersController.cs
@@ -36,7 +36,7 @@ public class UsersController(
     /// <summary>
     /// Returns the currently authenticated user.
     /// </summary>
-    [HttpGet("me")]
+    [HttpGet("Me")]
     public async Task<ActionResult<UserDto>> GetLoggedInUser(CancellationToken ct)
     {
         var user = await userService.GetCurrentUser(ct);
@@ -74,7 +74,7 @@ public class UsersController(
         return CreatedAtAction(nameof(GetById), new { id = user.Id }, userDto);
     }
 
-    [HttpPost("verify-email")]
+    [HttpPost("VerifyEmail")]
     public async Task<ActionResult<VerifyEmailResponse>> VerifyEmail(
         [FromBody] VerifyEmailRequest? request,
         CancellationToken ct)
@@ -97,7 +97,7 @@ public class UsersController(
         return Ok(UserDto.Create(user));
     }
 
-    [HttpPut("{id}/email")]
+    [HttpPut("{id}/Email")]
     public async Task<ActionResult<UserDto>> UpdateEmail(
         string id,
         [FromBody] UpdateUserEmailDto dto,
@@ -150,7 +150,7 @@ public class UsersController(
         return Ok(UserDto.Create(user));
     }
 
-    [HttpGet("find")]
+    [HttpGet("Find")]
     public async Task<ActionResult<IEnumerable<UserSearchResultDto>>> Find(string query,
         [FromQuery] bool includeExternalUsers = true, CancellationToken ct = default)
     {
@@ -164,7 +164,7 @@ public class UsersController(
     /// target. The real admin keeps their SurfConext identity, so authorisation here always checks the
     /// admin even when an impersonation is already active (enabling re-targeting, blocking escalation).
     /// </summary>
-    [HttpPost("impersonate")]
+    [HttpPost("Impersonate")]
     public async Task<ActionResult<UserImpersonationStartedDto>> Impersonate(
         [FromBody] StartUserImpersonationDto dto, CancellationToken ct)
     {

--- a/UvA.Workflow.Api/Versions/VersionsController.cs
+++ b/UvA.Workflow.Api/Versions/VersionsController.cs
@@ -14,7 +14,7 @@ public class VersionsController(
     : ApiControllerBase
 {
     /// Reload the default version from the configured source.
-    [HttpPost("reload")]
+    [HttpPost("Reload")]
     public async Task<ActionResult> Reload()
     {
         await rightsService.EnsureAuthorizedForAction(RoleAction.ViewAdminTools);
@@ -32,7 +32,7 @@ public class VersionsController(
     }
 
     /// Load a branch as a named preview version; send it back in the Workflow-Version header to view it.
-    [HttpPost("branch")]
+    [HttpPost("Branch")]
     public async Task<ActionResult<string>> LoadBranch([FromQuery] string @ref)
     {
         await rightsService.EnsureAuthorizedForAction(RoleAction.ViewAdminTools);
@@ -91,7 +91,7 @@ public class VersionsController(
         => Ok(modelServiceResolver.GetVersions().Select(v => v.Name));
 
     /// Version names plus provenance (commit + load time).
-    [HttpGet("details")]
+    [HttpGet("Details")]
     public ActionResult<IReadOnlyCollection<VersionInfo>> GetVersionDetails()
         => Ok(modelServiceResolver.GetVersions());
 }

--- a/UvA.Workflow.Api/WorkflowInstances/WorkflowInstancesController.cs
+++ b/UvA.Workflow.Api/WorkflowInstances/WorkflowInstancesController.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using UvA.Workflow.Api.Authentication;
 using UvA.Workflow.Api.Infrastructure;
@@ -89,7 +90,7 @@ public class WorkflowInstancesController(
     /// <summary>
     /// Returns all properties and values available to the admin data view.
     /// </summary>
-    [HttpGet("{id}/properties")]
+    [HttpGet("{id}/Properties")]
     public async Task<ActionResult<InstancePropertiesDto>> GetProperties(string id, CancellationToken ct)
     {
         var instance = await repository.GetById(id, ct);
@@ -113,7 +114,7 @@ public class WorkflowInstancesController(
     /// <summary>
     /// Overrides a single property. Always recorded in the instance journal.
     /// </summary>
-    [HttpPost("{id}/properties/{path}")]
+    [HttpPost("{id}/Properties/{path}")]
     public async Task<ActionResult> SaveProperty(string id, string path,
         [FromBody] SaveInstancePropertyRequest input, CancellationToken ct)
     {
@@ -140,7 +141,7 @@ public class WorkflowInstancesController(
         return NoContent();
     }
 
-    [HttpGet("{id}/impersonation/roles")]
+    [HttpGet("{id}/Impersonation/Roles")]
     public async Task<ActionResult<IEnumerable<ImpersonationRoleDto>>> GetImpersonationRoles(string id,
         CancellationToken ct)
     {
@@ -158,7 +159,7 @@ public class WorkflowInstancesController(
         return Ok(roles);
     }
 
-    [HttpPost("{id}/impersonation")]
+    [HttpPost("{id}/Impersonation")]
     public async Task<ActionResult<StartImpersonationResultDto>> StartImpersonation(string id,
         [FromBody] StartImpersonationDto input, CancellationToken ct)
     {
@@ -192,7 +193,7 @@ public class WorkflowInstancesController(
     /// TODO: remove this or use it to create some kind of generic export function 
     /// </summary>
     [Authorize(AuthenticationSchemes = WorkflowAuthenticationDefaults.AnyScheme)]
-    [HttpGet("instances/{workflowDefinition}/full")]
+    [HttpGet("Instances/{workflowDefinition}/Full")]
     public async Task<ActionResult<IEnumerable<Dictionary<string, object>>>> GetFullInstances(string workflowDefinition,
         [FromQuery] string[] properties, CancellationToken ct)
     {
@@ -208,13 +209,13 @@ public class WorkflowInstancesController(
         return Ok(contexts
             .OrderByDescending(i => i.Id)
             .Select(row => properties.ToDictionary(
-                p => p,
+                JsonNamingPolicy.CamelCase.ConvertName,
                 p => row.Get(p)
             )));
     }
 
     [Authorize(AuthenticationSchemes = WorkflowAuthenticationDefaults.AnyScheme)]
-    [HttpGet("instances/{workflowDefinition}")]
+    [HttpGet("Instances/{workflowDefinition}")]
     public async Task<ActionResult<IEnumerable<Dictionary<string, object>>>> GetInstances(string workflowDefinition,
         [FromQuery] string[] properties, CancellationToken ct, [FromQuery] bool includeTitle = false)
     {
@@ -253,13 +254,13 @@ public class WorkflowInstancesController(
                 return row;
             })
             .Select(row => row.ToDictionary(
-                k => char.ToLowerInvariant(k.Key[0]) + k.Key[1..],
+                k => JsonNamingPolicy.CamelCase.ConvertName(k.Key),
                 v => v.Value
             )));
     }
 
     [Authorize(AuthenticationSchemes = WorkflowAuthenticationDefaults.AnyScheme)]
-    [HttpPost("instances/{workflowDefinition}/recalculate-current-step")]
+    [HttpPost("Instances/{workflowDefinition}/RecalculateCurrentStep")]
     public async Task<ActionResult<RecalculateCurrentStepsResultDto>> RecalculateCurrentSteps(
         string workflowDefinition, CancellationToken ct)
     {
@@ -288,7 +289,7 @@ public class WorkflowInstancesController(
     }
 
 
-    [HttpPost("{id}/related-users/{property}")]
+    [HttpPost("{id}/RelatedUsers/{property}")]
     public async Task<ActionResult> AssignRelatedUser(string id, string property,
         [FromBody] AssignRelatedUserRequest input, CancellationToken ct)
     {
@@ -340,7 +341,7 @@ public class WorkflowInstancesController(
         }
     }
 
-    [HttpDelete("{id}/related-users/{property}/{userId}")]
+    [HttpDelete("{id}/RelatedUsers/{property}/{userId}")]
     public async Task<ActionResult> RemoveRelatedUser(string id, string property, string userId, CancellationToken ct)
     {
         if (await userService.GetCurrentUser(ct) == null)


### PR DESCRIPTION
DN-3931

All literal route segments are PascalCase, hyphens removed.

### Routes
- Hyphens gone: `verify-email` → `VerifyEmail`, `recalculate-current-step` → `RecalculateCurrentStep`, `related-users` → `RelatedUsers`
- Lowercase segments PascalCased: `me`, `find`, `impersonate`, `run`, `artifacts`, `reload`, `branch`, `details`, `properties`, `impersonation/roles`, `instances`, `full`, `email`, `dummyData`
- `StepsController` moved off its absolute `/api/instances/{id}/steps/{name}/versions` onto its own unused `[Route("[controller]")]` base, now `GET /Steps/{instanceId}/{stepName}/Versions`. Added `/Steps` to the PR ingress `apiPaths` (and dropped a duplicate `/Submissions` plus a stale `/Artifacts` that has no controller).

### Properties
Already camelCase everywhere, since `PropertyNamingPolicy` is never overridden. The only gap was dictionary keys, which bypass the naming policy: `/Instances/{wd}` hand-rolled a first-char lowercase while `/Instances/{wd}/Full` did nothing at all. Both now use `JsonNamingPolicy.CamelCase.ConvertName`.

Canvas LTI untouched: `/oidc`, `/signin-oidc`, `/jwks` come from the UvA.LTI middleware.